### PR TITLE
SearchHistory bug fixed

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -94,7 +94,7 @@ function display5DayForecastCard (citySearched) {
             } 
         }
     }
-    return 1;
+    fetchCity(citySearched)
 }
 
 function fetchCity (city) {  
@@ -133,17 +133,15 @@ $(document).ready(function (){
     const cityButton = $('#searchHistory');
 
     cityButton[0].addEventListener('click', function(event){
-        display5DayForecastCard(event.target.id);
+        if(event.target.type === 'button') {
+            display5DayForecastCard(event.target.id);
+        }
     })
 
     srcButton[0].addEventListener('click', function(event){
         event.preventDefault();
         const citySearched = $('#citySearch').val();
-        var status =  display5DayForecastCard(citySearched);
-        
-        if(status === 1) {
-            fetchCity(citySearched);        
-        }
+        display5DayForecastCard(citySearched);
     });
 });
 


### PR DESCRIPTION
Added event listener to make sure the eventlistener only activates when one of the city buttons are pressed instead of any thing within the area.

Also changed the display5DayForecastCard function to run the fetch function instead of returning 1. This helps for the buttons as well. If the information stored in local storage is changed if you search the city or click on the buttons now.