### PR TITLE
Ease of use features

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -80,10 +80,15 @@ function generateCard(city) {
 }
 
 function display5DayForecastCard (citySearched) {
-    cardArea.empty();
+    var counter = 0;
     for (data of dataHistoryArray) {
         if(citySearched.toLowerCase() === data.city.name.toLowerCase()) {
+            cardArea.empty();
+            const tmp = dataHistoryArray.splice(counter, 1);
+            dataHistoryArray.push(tmp[0]);
+            displaySearchHistory();
             if(dayjs().diff(dayjs(data.list[0].dt_txt), 'd') < 1){
+                localStorage.setItem('dataHistory', JSON.stringify(dataHistoryArray));
                 displayForecastCard(data);
                 for (let i = 0; i < 40; i++){
                     if(i%8 === 0) {
@@ -93,6 +98,7 @@ function display5DayForecastCard (citySearched) {
                 return 0;
             } 
         }
+        counter++;
     }
     fetchCity(citySearched)
 }
@@ -141,7 +147,11 @@ $(document).ready(function (){
     srcButton[0].addEventListener('click', function(event){
         event.preventDefault();
         const citySearched = $('#citySearch').val();
-        display5DayForecastCard(citySearched);
+        if(citySearched === '') {
+            alert('please enter city before pressing search');
+            return;
+        } 
+       display5DayForecastCard(citySearched);
     });
 });
 


### PR DESCRIPTION
Changed cardArea.empty to be deeper inside the display function to ensure that even if the user doesn't enter a valid city, it doesn't take away the previous cards. 

When any search or city button is pressed, the search history is refreshed to put the last searched or clicked city back at the top for chronological order.

If no city is searched, user is alerted that they need to enter a city before searching.